### PR TITLE
Ignore missing message attribute in failure element

### DIFF
--- a/test_archiver/output_parser.py
+++ b/test_archiver/output_parser.py
@@ -241,7 +241,13 @@ class JUnitOutputParser(XmlOutputParser):
             self.archiver.begin_status('PASS', elapsed=elapsed)
         elif name == 'failure':
             self.archiver.update_status('FAIL')
-            self.archiver.log_message('FAIL', attrs.getValue('message'))
+            try:
+                self.archiver.log_message('FAIL', attrs.getValue('message'))
+            except KeyError:
+                print("Ignoring empty message attribute in failure element")
+                # jest-junit does not add 'message' attribute to 'failure' xml element
+                # https://github.com/jest-community/jest-junit
+                pass
         elif name == 'error':
             self.archiver.update_status('FAIL')
             self.archiver.log_message('ERROR', attrs.getValue('message'))


### PR DESCRIPTION
Jest-junit reporter (https://github.com/jest-community/jest-junit) writes failure element without message attributes.