### PR TITLE
fixes sqlite insert integrity issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,12 @@ If the tests are executed in a CI environment the build number/id is an excellen
 The series can also be indicated using metadata. Any metadata with name prefixed with `series` are interpreted as series information. This is especially useful when using listeners. For example when using Robot Framework metadata `--metadata team:A-Team --metadata series:JENKINS_JOB_NAME#BUILD_NUMBER`
 
 # Release notes
-- TBD (TBD)
+- 1.2.0 (TBD)
+  * Important database integrity fix when using sqlite database
   * Record test criticality (Robot Framework specific)
+  * Redesign of configurations management
+    - Allows using both config file and command line arguments uniformly
+    - CLI arguments override options set in config file
 
 - 1.1.3 (2020-06-09)
   * Performance fix for the schema existance check

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -7,7 +7,7 @@ from database import PostgresqlDatabase, SQLiteDatabase
 from database import IntegrityError
 from archiver_listeners import ChangeEngineListener
 
-ARCHIVER_VERSION = "1.1.3"
+ARCHIVER_VERSION = "1.2.0-dev"
 
 SUPPORTED_TIMESTAMP_FORMATS = (
         "%Y%m%d %H:%M:%S.%f",
@@ -226,7 +226,12 @@ class TestRun(FingerprintedItem):
                 'generator': generator,
                 'rpa': rpa,
                 'dryrun': dryrun}
-        self.id = self.archiver.db.insert_and_return_id('test_run', data)
+        try:
+            self.id = self.archiver.db.insert_and_return_id('test_run', data)
+        except IntegrityError:
+            raise IntegrityError('ERROR: Unable to insert results. Probably the test archive schema is not '
+                                 'compatible with the version of TestArchiver you are using. '
+                                 'Consider updating to 2.0 or later.')
 
 
 class Suite(FingerprintedItem):

--- a/test_archiver/database.py
+++ b/test_archiver/database.py
@@ -184,7 +184,7 @@ class PostgresqlDatabase(Database):
             )
         try:
             self._execute(sql, [data[key] for key in keys])
-        except psycopg2.errors.UniqueViolation:
+        except (psycopg2.errors.UniqueViolation, psycopg2.errors.NotNullViolation):
             raise IntegrityError()
 
 
@@ -252,25 +252,11 @@ class SQLiteDatabase(Database):
         return row_id
 
     def return_id_or_insert_and_return_id(self, table, data, key_fields):
-        sql = "INSERT OR IGNORE INTO {table}({fields}) VALUES ({value_placeholders});"
-        keys = list(data)
-        sql = sql.format(
-            table=table,
-            fields=','.join(keys),
-            value_placeholders=','.join(['?' for _ in keys]),
-            )
-        self._execute(sql, [data[key] for key in keys])
+        self.insert_or_ignore(table, data)
         return self._fetch_id(table, data, key_fields)
 
     def insert_and_return_id(self, table, data, key_fields=None):
-        sql = "INSERT OR IGNORE INTO {table}({fields}) VALUES ({value_placeholders});"
-        keys = list(data)
-        sql = sql.format(
-            table=table,
-            fields=','.join(keys),
-            value_placeholders=','.join(['?' for _ in keys]),
-            )
-        self._execute(sql, [data[key] for key in keys])
+        self.insert(table, data)
         row_id = self._fetch_id(table, data, key_fields)
         return row_id
 


### PR DESCRIPTION
Fixes the insert_and_return_id() method of the SQLite database adapter as previous implementation would not fail if the insert was unsuccessful. Possibly leading to database integrity issues being ignored by the script.

Also updated the release notes ready for release.