### PR TITLE
Feature/time adjust secs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,27 @@ is useful if the tests and archiving are performed in the same place and time.
 This assumes that if multiple computers are used that their timezone and daylight savings settings are identical.
 Care must also be taken that tests are not run just before a daylight savings time adjust and archived just after
 as times will be out by one hour. This could easily happen if long running tests cross a timezone adjust boundary.
-This can be set using --time_adjust_with_system_timezone.
+This can be set using --time-adjust-with-system-timezone.
 
 The ArchiverRobotListener allows for the second option if its adjust_with_system_timezone argument is set to True.
+
+To ensure any of the optional adjustments are traceable, two meta data values are added to the suites' test run.
+If time-adjust-secs is set to a value, time_adjust_secs with that value is written to the suite_metadata table.
+If `--time-adjust-with-system-timezone` option is included, then the addition of the time-adjust-secs and the
+system timezone is written to the suite_metadata tables as time_adjust_secs_total.
+
+e.g with command line
+
+    output_parser.py --time-adjust-secs -3600 --time-adjust-with-system-timezone ...
+
+the following values would be added to suite_metadata table for (GMT+2)
+
+ - time_adjust_secs with value -3600
+ - time_adjust_secs_total with -10800.
+
+This example is mimicking adding daylight savings (1hr = 3600 secs) onto
+a system offset secs of 7200 (GMT+2). i.e. if the computer being used had the 'daylight savings' setting
+of and you want to manually add it during archiving.
 
 
 # Release notes

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ system timezone is written to the suite_metadata tables as time_adjust_secs_tota
 
 e.g with command line
 
-    output_parser.py --time-adjust-secs -3600 --time-adjust-with-system-timezone ...
+`output_parser.py --time-adjust-secs -3600 --time-adjust-with-system-timezone ...`
 
 the following values would be added to suite_metadata table for (GMT+2)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,36 @@ If the tests are executed in a CI environment the build number/id is an excellen
 
 The series can also be indicated using metadata. Any metadata with name prefixed with `series` are interpreted as series information. This is especially useful when using listeners. For example when using Robot Framework metadata `--metadata team:A-Team --metadata series:JENKINS_JOB_NAME#BUILD_NUMBER`
 
+## Timestamp adjustment
+
+Some test frameworks use local time in their timestamps. For archiving into databases this can be problematic if tests
+are viewed and or run in different timezones. To address this two ways to adjust the time back to GMT/UTC are provided.
+
+The first allows the user to apply an adjustment of a fixed time in seconds of their choosing. This is useful for cases
+where tests were already run and the place/timezone where they were run are known. This option is useful if you are
+archiving in a different location to where tests are  run. The time value provided as an option is added to the 
+timestamp. Care must be taken with places where summer time is different (usually +1hr).
+
+For example if test were run in Finland (GMT+2), plus 1 hour in summer, calculate total hours by minutes and seconds 
+and invert to adjust in correct direction, i.e. -(2+1)*60*60, so --time-adjust-secs -10800 in summer time, 
+and -7200 otherwise. 
+
+The second provides for automated adjustment based on the system timezone and/or daylight savings if it applies. This
+is useful if the tests and archiving are performed in the same place and time.
+This assumes that if multiple computers are used that their timezone and daylight savings settings are identical.
+Care must also be taken that tests are not run just before a daylight savings time adjust and archived just after
+as times will be out by one hour. This could easily happen if long running tests cross a timezone adjust boundary.
+This can be set using --time_adjust_with_system_timezone.
+
+The ArchiverRobotListener allows for the second option if its adjust_with_system_timezone argument is set to True.
+
+
 # Release notes
+- tbd
+  * Ability to adjust times as reported by timestamps in test results.
+    - `time-adjust-secs` allows for manual adjustment of the timestamps with given value
+    - `time-adjust-with-system-timezone` allows for automatic adjustment of timestamps by timezone and/or daylight savings.
+
 - 2.1.0 (2020-09-16)
   * New options for controlling archiving of keywords and log messages
     - `--no-keywords` for ignoring all keyword data

--- a/test_archiver/ArchiverRobotListener.py
+++ b/test_archiver/ArchiverRobotListener.py
@@ -20,12 +20,8 @@ class ArchiverRobotListener:
                                                  'password': pw,
                                                  'host': host,
                                                  'port': port})
-        if adjust_with_system_timezone:
-            import time
-            if time.daylight == 0:
-                config.time_adjust_secs = time.timezone
-            else:
-                config.time_adjust_secs = time.altzone
+
+        config.time_adjust_with_system_timezone = adjust_with_system_timezone
 
         database = archiver.database_connection(config)
         self.archiver = archiver.Archiver(database, config)

--- a/test_archiver/ArchiverRobotListener.py
+++ b/test_archiver/ArchiverRobotListener.py
@@ -10,7 +10,7 @@ class ArchiverRobotListener:
     ROBOT_LISTENER_API_VERSION = 2
 
     def __init__(self, config_file_or_database,
-                 db_engine=None, user=None, pw=None, host=None, port=5432):
+                 db_engine=None, user=None, pw=None, host=None, port=5432, adjust_with_system_timezone=False):
         if not db_engine:
             config = configs.Config(file_config=config_file_or_database)
         else:
@@ -20,6 +20,13 @@ class ArchiverRobotListener:
                                                  'password': pw,
                                                  'host': host,
                                                  'port': port})
+        if adjust_with_system_timezone:
+            import time
+            if time.daylight == 0:
+                config.time_adjust_secs = time.timezone
+            else:
+                config.time_adjust_secs = time.altzone
+
         database = archiver.database_connection(config)
         self.archiver = archiver.Archiver(database, config)
         self.archiver.test_type = "Robot Framework"

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -313,6 +313,12 @@ class Suite(FingerprintedItem):
         if isinstance(self.parent_item, TestRun) and self.archiver.additional_metadata:
             for name in self.archiver.additional_metadata:
                 self.metadata[name] = self.archiver.additional_metadata[name]
+        if self.archiver.config.time_adjust_secs != 0:
+            self.metadata["time_adjust_secs"] = self.archiver.config.time_adjust_secs
+        if self.archiver.config.time_adjust_with_system_timezone:
+            time_adjust = TimeAdjust(self.archiver.config.time_adjust_secs,
+                                     self.archiver.config.time_adjust_with_system_timezone)
+            self.metadata["time_adjust_secs_total"] = time_adjust.secs()
         for name in self.metadata:
             content = self.metadata[name]
             data = {'name': name, 'value': content,

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -1,6 +1,7 @@
 # pylint: disable=C0103
 
 import sys
+import time
 from hashlib import sha1
 from datetime import datetime, timedelta
 from collections import defaultdict
@@ -23,6 +24,21 @@ SUPPORTED_TIMESTAMP_FORMATS = (
     )
 
 MAX_LOG_MESSAGE_LENGTH = 2000
+
+
+class TimeAdjust:
+    def __init__(self, secs, adjust_to_system):
+        self._time_adjust_secs = secs
+        self._adjust_to_system = adjust_to_system
+
+    def secs(self):
+        secs = self._time_adjust_secs
+        if self._adjust_to_system:
+            if time.daylight == 0:
+                secs = secs + time.timezone
+            else:
+                secs = secs + time.altzone
+        return secs
 
 
 class TestItem:

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -154,7 +154,7 @@ def base_argument_parser(description):
                              'This option may be used in conjunction with --time-adjust-with-system-timezone if '
                              'desired.')
     parser.add_argument('--time-adjust-with-system-timezone', dest='time_adjust_with_system_timezone', default=None,
-                        action='store_false',
+                        action='store_true',
                         help='Adjust the time in timestamps by the system timezone (including daylight savings adjust).'
                              ' If you are archiving tests in the same timezone as you are running tests, setting this '
                              'option will ensure time written to the database is in UTC/GMT time. This assumes that if '

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -141,28 +141,28 @@ def base_argument_parser(description):
                               'By default archives all available log messages.'))
     parser.add_argument('--ignore-logs', action='store_true', help='Do not archive any log messages')
     parser.add_argument('--time-adjust-secs', dest='time_adjust_secs', default=0,
-                        help='Adjust time in timestamps by given seconds. This can be used to change time to utc '
-                             'before writing the results to database, especially if the test system uses local time, '
-                             'such as robot framework. '
-                             'For example if test were run in Finland (GMT+3) in summer (+1hr), calculate total hours '
-                             'by minutes and seconds and invert to adjust in correct direction, i.e. -(3+1)*60*60, so '
-                             '--time-adjust-secs -14400. '
-                             'This option is useful if you are archiving in a different location to where tests are '
-                             'run.'
-                             'If you are running tests and archiving in same timezone, time-adjust-with-system-timezone'
-                             ' may be a better option. '
-                             'This option may be used in conjunction with --time-adjust-with-system-timezone if '
-                             'desired.')
-    parser.add_argument('--time-adjust-with-system-timezone', dest='time_adjust_with_system_timezone', default=None,
-                        action='store_true',
-                        help='Adjust the time in timestamps by the system timezone (including daylight savings adjust).'
-                             ' If you are archiving tests in the same timezone as you are running tests, setting this '
-                             'option will ensure time written to the database is in UTC/GMT time. This assumes that if '
-                             'multiple computers are used that their timezone and daylight savings settings are '
-                             'identical. '
-                             'Take care also that you do not run tests just before a daylight savings time adjust and '
-                             'archive just after, as times will be out by one hour. This could easily happen if long '
-                             'running tests cross a timezone adjust boundary. '
+                        help='Adjust time in timestamps by given seconds. This can be used to change time '
+                             'to utc before writing the results to database, especially if the test system '
+                             'uses local time, such as robot framework. '
+                             'For example if test were run in Finland (GMT+3) in summer (+1hr), calculate '
+                             'total hours by minutes and seconds and invert to adjust in correct direction,'
+                             ' i.e. -(3+1)*60*60, so --time-adjust-secs -14400. '
+                             'This option is useful if you are archiving in a different location to where '
+                             'tests are run.'
+                             'If you are running tests and archiving in same timezone, '
+                             'time-adjust-with-system-timezone may be a better option. '
+                             'This option may be used in conjunction with '
+                             '--time-adjust-with-system-timezone if desired.')
+    parser.add_argument('--time-adjust-with-system-timezone', dest='time_adjust_with_system_timezone',
+                        default=None, action='store_true',
+                        help='Adjust the time in timestamps by the system timezone (including daylight '
+                             'savings adjust). If you are archiving tests in the same timezone as you are '
+                             'running tests, setting this option will ensure time written to the database '
+                             'is in UTC/GMT time. This assumes that if multiple computers are used that '
+                             'their timezone and daylight savings settings are identical. '
+                             'Take care also that you do not run tests just before a daylight savings time '
+                             'adjust and archive just after, as times will be out by one hour. This could '
+                             'easily happen if long running tests cross a timezone adjust boundary. '
                              'This option may be used in conjunction with --time-adjust-secs.')
     return parser
 

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -92,7 +92,7 @@ class Config():
         try:
             return value if value is None else cast_as(value)
         except ValueError as value_error:
-            print("Error: incompatiple value for option '{}'".format(name))
+            print("Error: incompatible value for option '{}'".format(name))
             raise value_error
 
     def resolve_list_option(self, name):

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -138,7 +138,18 @@ def base_argument_parser(description):
                               'By default archives all available log messages.'))
     parser.add_argument('--ignore-logs', action='store_true', help='Do not archive any log messages')
     parser.add_argument('--time-adjust-secs', dest='time_adjust_secs', default=0,
-                        help='Adjust time in timestamps by given seconds')
+                        help='Adjust time in timestamps by given seconds. This can be used to change time to utc '
+                             'before writing the results to database, especially if the test system uses local time, '
+                             'such as robot framework. '
+                             'For example if test were run in Finland (GMT+3) in summer (+1hr), calculate total hours '
+                             'by minutes and seconds and invert to adjust in correct direction, i.e. -(3+1)*60*60, so '
+                             '--time-adjust-secs -14400. '
+                             'This option is useful if you are archiving in a different location to where tests are '
+                             'run.'
+                             'If you are running tests and archiving in same timezone, time-adjust-with-system-timezone'
+                             ' may be a better option. '
+                             'This option may be used in conjunction with --time-adjust-with-system-timezone if '
+                             'desired.')
     return parser
 
 def configuration(argument_parser):

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -77,6 +77,9 @@ class Config():
 
         self.time_adjust_secs = self.resolve_option('time_adjust_secs', default=0, cast_as=int)
 
+        self.time_adjust_with_system_timezone = self.resolve_option('time_adjust_with_system_timezone',
+                                                                    default=False, cast_as=bool)
+
 
     def resolve_option(self, name, default=None, cast_as=str):
         value = None
@@ -150,6 +153,17 @@ def base_argument_parser(description):
                              ' may be a better option. '
                              'This option may be used in conjunction with --time-adjust-with-system-timezone if '
                              'desired.')
+    parser.add_argument('--time-adjust-with-system-timezone', dest='time_adjust_with_system_timezone', default=None,
+                        action='store_false',
+                        help='Adjust the time in timestamps by the system timezone (including daylight savings adjust).'
+                             ' If you are archiving tests in the same timezone as you are running tests, setting this '
+                             'option will ensure time written to the database is in UTC/GMT time. This assumes that if '
+                             'multiple computers are used that their timezone and daylight savings settings are '
+                             'identical. '
+                             'Take care also that you do not run tests just before a daylight savings time adjust and '
+                             'archive just after, as times will be out by one hour. This could easily happen if long '
+                             'running tests cross a timezone adjust boundary. '
+                             'This option may be used in conjunction with --time-adjust-secs.')
     return parser
 
 def configuration(argument_parser):

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -75,6 +75,8 @@ class Config():
 
         self.change_engine_url = self.resolve_option('change_engine_url')
 
+        self.time_adjust_secs = self.resolve_option('time_adjust_secs', default=0, cast_as=int)
+
 
     def resolve_option(self, name, default=None, cast_as=str):
         value = None
@@ -135,6 +137,8 @@ def base_argument_parser(description):
                         help=('Sets a cut off level for archived log messages. '
                               'By default archives all available log messages.'))
     parser.add_argument('--ignore-logs', action='store_true', help='Do not archive any log messages')
+    parser.add_argument('--time-adjust-secs', dest='time_adjust_secs', default=0,
+                        help='Adjust time in timestamps by given seconds')
     return parser
 
 def configuration(argument_parser):


### PR DESCRIPTION
As some test systems, like robot framework use local time, allow for timestamps to be adjusted for both output parser and robot listener.
For output parser provide a --time-adjust-secs option, which will adjust the timestamps from xml files by the given seconds (plus or negative). This will allow the user to archive data to database in utc time.
For the robot listener, allow the user to specify they want to adjust the time by system timezone and/or daylight savings offset.

There is a pull request against robotframework to allow saving utc timestamps, but even with that, older versions of robot framework would benefit from allow TestArchiver to adjust the time as desired.