### PR TITLE
Feature/mysql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ optional arguments:
   --version, -v         show program's version number and exit
   --config CONFIG_FILE  path to JSON config file containing database
                         credentials
-  --dbengine DB_ENGINE  Database engine, postgresql or sqlite (default)
+  --dbengine DB_ENGINE  Database engine, postgresql, mysql or sqlite (default)
   --database DATABASE   database name
   --host HOST           database host name
   --user USER           database user
@@ -165,6 +165,7 @@ of and you want to manually add it during archiving.
   * Ability to adjust times as reported by timestamps in test results.
     - `time-adjust-secs` allows for manual adjustment of the timestamps with given value
     - `time-adjust-with-system-timezone` allows for automatic adjustment of timestamps by timezone and/or daylight savings.
+  * MySQL support
 
 - 2.1.0 (2020-09-16)
   * New options for controlling archiving of keywords and log messages

--- a/test_archiver/ArchiverRobotListener.py
+++ b/test_archiver/ArchiverRobotListener.py
@@ -20,8 +20,7 @@ class ArchiverRobotListener:
                                                  'password': pw,
                                                  'host': host,
                                                  'port': port})
-
-        config.time_adjust_with_system_timezone = adjust_with_system_timezone
+            config.time_adjust_with_system_timezone = adjust_with_system_timezone
 
         database = archiver.database_connection(config)
         self.archiver = archiver.Archiver(database, config)

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -208,7 +208,8 @@ class FingerprintedItem(TestItem):
                 'setup_status': self.setup_status,
                 'execution_status': self.execution_status,
                 'teardown_status': self.teardown_status,
-                'start_time': self.start_time,
+                'start_time': adjusted_timestamp(self.start_time, self._time_adjust.secs())
+                              if self.start_time else None,
                 'elapsed': self.elapsed_time,
                 'setup_elapsed': self.elapsed_time_setup,
                 'execution_elapsed': self.elapsed_time_execution,
@@ -256,7 +257,8 @@ class TestRun(FingerprintedItem):
         super(TestRun, self).__init__(archiver, '')
         data = {'archived_using': archived_using,
                 'archiver_version': version.ARCHIVER_VERSION,
-                'generated': generated,
+                'generated': adjusted_timestamp(generated, self._time_adjust.secs())
+                             if generated else None,
                 'generator': generator,
                 'rpa': rpa,
                 'dryrun': dryrun,

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -717,6 +717,8 @@ def adjusted_timestamp_to_datetime(timestamp, time_adjust_secs=0):
 
 
 def adjusted_timestamp(timestamp, time_adjust_secs=0):
-    adjusted_datetime = adjusted_timestamp_to_datetime(timestamp, time_adjust_secs)
-    adjusted_stamp = adjusted_datetime.isoformat(timespec='milliseconds')
+    adjusted_stamp = timestamp
+    if timestamp:
+        adjusted_datetime = adjusted_timestamp_to_datetime(timestamp, time_adjust_secs)
+        adjusted_stamp = adjusted_datetime.isoformat(timespec='milliseconds')
     return adjusted_stamp

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -717,8 +717,6 @@ def adjusted_timestamp_to_datetime(timestamp, time_adjust_secs=0):
 
 
 def adjusted_timestamp(timestamp, time_adjust_secs=0):
-    adjusted_stamp = timestamp
-    if time_adjust_secs != 0:
-        adjusted_datetime = adjusted_timestamp_to_datetime(timestamp, time_adjust_secs)
-        adjusted_stamp = adjusted_datetime.isoformat(timespec='milliseconds')
+    adjusted_datetime = adjusted_timestamp_to_datetime(timestamp, time_adjust_secs)
+    adjusted_stamp = adjusted_datetime.isoformat(timespec='milliseconds')
     return adjusted_stamp

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -118,7 +118,7 @@ def base_argument_parser(description):
                         help='path to JSON config file containing database credentials')
 
     parser.add_argument('--dbengine', dest='db_engine',
-                        help='Database engine, postgresql or sqlite (default)')
+                        help='Database engine, postgresql, mysql or sqlite (default)')
     parser.add_argument('--database', help='database name')
     parser.add_argument('--host', help='database host name', default=None)
     parser.add_argument('--user', help='database user')

--- a/test_archiver/database.py
+++ b/test_archiver/database.py
@@ -486,12 +486,12 @@ class MySqlDatabase(PostgresqlDatabase):
     def _handle_values(self, values):
         handled_values = []
         for value in values:
-            if type(value) == list:
-                v = json.dumps(value)
-                handled_values.append(v)
-            elif type(value) == str and value.lower() in ('true', 'false'):
-                v = (value.lower() == 'true')
-                handled_values.append(v)
+            if isinstance(value, list):
+                json_value = json.dumps(value)
+                handled_values.append(json_value)
+            elif isinstance(value, str) and value.lower() in ('true', 'false'):
+                json_value = (value.lower() == 'true')
+                handled_values.append(json_value)
             else:
                 handled_values.append(value)
         return handled_values
@@ -553,7 +553,7 @@ class MySqlDatabase(PostgresqlDatabase):
             )
         try:
             self._execute(sql, [data[key] for key in keys])
-        except (mysql_connector.IntegrityError):
+        except mysql_connector.IntegrityError:
             raise IntegrityError()
 
     def _execute_multi(self, sql, values=None):
@@ -583,8 +583,8 @@ class MySqlDatabase(PostgresqlDatabase):
             for line in lines:
                 statement = line.strip()
                 if statement:
-                    v = values if 'VALUES' in statement else None
-                    cursor.execute(statement, v)
+                    values_or_none = values if 'VALUES' in statement else None
+                    cursor.execute(statement, values_or_none)
                     row = cursor.fetchone()
                     self.commit()
         finally:

--- a/test_archiver/database.py
+++ b/test_archiver/database.py
@@ -184,6 +184,7 @@ class PostgresqlDatabase(BaseDatabase):
             user=self.user,
             password=self.password,
             sslmode='require' if self.require_ssl else 'prefer',
+            port=self.port
         )
 
     def _initialize_schema(self):

--- a/test_archiver/schemas/migrations/mysql/0001-schema_update_table_and_log_message_index.sql
+++ b/test_archiver/schemas/migrations/mysql/0001-schema_update_table_and_log_message_index.sql
@@ -1,0 +1,23 @@
+-- Start versioning the schema and record updates
+CREATE TABLE schema_updates (
+    id serial PRIMARY KEY,
+    schema_version int UNIQUE NOT NULL,
+    applied_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    initial_update boolean DEFAULT false,
+    applied_by text
+);
+-- Pre 2.0 Schema is version 0
+INSERT INTO schema_updates (schema_version, initial_update, applied_by)
+VALUES (0, true, '{applied_by}');
+
+-- Add schema_version column to test_runs.
+-- Makes the schema incompatible for older versions of TestArchiver on purpose.
+ALTER TABLE test_run ADD COLUMN schema_version int
+    REFERENCES schema_updates(schema_version) NOT NULL DEFAULT 0;
+ALTER TABLE test_run ALTER COLUMN schema_version SET DEFAULT NULL;
+
+-- Adds missing index for log_message table
+CREATE INDEX test_log_message_index ON log_message(test_run_id, suite_id, test_id);
+
+INSERT INTO schema_updates (schema_version, applied_by)
+VALUES (1, '{applied_by}');

--- a/test_archiver/schemas/migrations/mysql/0002-execution_paths.sql
+++ b/test_archiver/schemas/migrations/mysql/0002-execution_paths.sql
@@ -1,0 +1,7 @@
+-- Adds columns to record execution paths
+ALTER TABLE suite_result ADD COLUMN execution_path text DEFAULT NULL;
+ALTER TABLE test_result ADD COLUMN execution_path text DEFAULT NULL;
+ALTER TABLE log_message ADD COLUMN execution_path text DEFAULT NULL;
+
+INSERT INTO schema_updates (schema_version, applied_by)
+VALUES (2, '{applied_by}');

--- a/test_archiver/schemas/schema_mysql.sql
+++ b/test_archiver/schemas/schema_mysql.sql
@@ -1,0 +1,148 @@
+CREATE TABLE schema_updates (
+    id serial PRIMARY KEY,
+    schema_version int UNIQUE NOT NULL,
+    applied_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    initial_update boolean DEFAULT false,
+    applied_by varchar(200)
+);
+INSERT INTO schema_updates(schema_version, initial_update, applied_by) VALUES (2, true, '{applied_by}');
+
+CREATE TABLE test_series (
+    id serial PRIMARY KEY,
+    name varchar(200) NOT NULL,
+    team varchar(200) NOT NULL
+);
+CREATE UNIQUE INDEX unique_test_series_idx ON test_series(team, name);
+
+CREATE TABLE test_run (
+    id serial PRIMARY KEY,
+    imported_at timestamp DEFAULT CURRENT_TIMESTAMP,
+    archived_using varchar(200),
+    archiver_version varchar(200),
+    generator varchar(200),
+    `generated` timestamp,
+    rpa boolean,
+    dryrun boolean,
+    ignored boolean DEFAULT false,
+    schema_version int NOT NULL REFERENCES schema_updates(schema_version)
+);
+
+CREATE TABLE test_series_mapping (
+    series int REFERENCES test_series(id),
+    test_run_id int REFERENCES test_run(id),
+    build_number int NOT NULL,
+    build_id varchar(500),
+    PRIMARY KEY (series, test_run_id, build_number)
+);
+
+CREATE TABLE suite (
+    id serial PRIMARY KEY,
+    name varchar(200),
+    full_name varchar(200) NOT NULL,
+    repository varchar(200) NOT NULL
+);
+CREATE UNIQUE INDEX unique_suite_idx ON suite(repository, full_name);
+
+CREATE TABLE suite_result (
+    suite_id int NOT NULL REFERENCES suite(id) ON DELETE CASCADE,
+    test_run_id int NOT NULL REFERENCES test_run(id) ON DELETE CASCADE,
+    status varchar(20),
+    setup_status varchar(20),
+    execution_status varchar(20),
+    teardown_status varchar(20),
+    start_time timestamp,
+    elapsed int,
+    setup_elapsed int,
+    execution_elapsed int,
+    teardown_elapsed int,
+    fingerprint varchar(100),
+    setup_fingerprint varchar(100),
+    execution_fingerprint varchar(100),
+    teardown_fingerprint varchar(100),
+    execution_path text,
+    PRIMARY KEY (test_run_id, suite_id)
+);
+CREATE UNIQUE INDEX unique_suite_result_idx ON suite_result(start_time, fingerprint);
+
+CREATE TABLE test_case (
+    id serial PRIMARY KEY,
+    name varchar(200) NOT NULL,
+    full_name varchar(200) NOT NULL,
+    suite_id int NOT NULL REFERENCES suite(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX unique_test_case_idx ON test_case(full_name, suite_id);
+
+CREATE TABLE test_result (
+    test_id int NOT NULL REFERENCES test_case(id) ON DELETE CASCADE,
+    test_run_id int NOT NULL REFERENCES test_run(id) ON DELETE CASCADE,
+    status varchar(50),
+    setup_status varchar(50),
+    execution_status varchar(50),
+    teardown_status varchar(50),
+    start_time timestamp,
+    elapsed int,
+    setup_elapsed int,
+    execution_elapsed int,
+    teardown_elapsed int,
+    critical boolean,
+
+    fingerprint varchar(100),
+    setup_fingerprint varchar(100),
+    execution_fingerprint varchar(100),
+    teardown_fingerprint varchar(100),
+    execution_path varchar(200),
+    PRIMARY KEY (test_run_id, test_id)
+);
+
+CREATE TABLE log_message (
+    id serial PRIMARY KEY,
+    execution_path text,
+    test_run_id int NOT NULL REFERENCES test_run(id) ON DELETE CASCADE,
+    test_id int REFERENCES test_case(id) ON DELETE CASCADE,
+    suite_id int NOT NULL REFERENCES suite(id) ON DELETE CASCADE,
+    timestamp timestamp,
+    log_level varchar(200) NOT NULL,
+    message text
+);
+CREATE INDEX test_log_message_index ON log_message(test_run_id, suite_id, test_id);
+
+CREATE TABLE suite_metadata (
+    suite_id int NOT NULL REFERENCES suite(id) ON DELETE CASCADE,
+    test_run_id int NOT NULL REFERENCES test_run(id) ON DELETE CASCADE,
+    name varchar(200) NOT NULL,
+    value text,
+    PRIMARY KEY (test_run_id, suite_id, name)
+);
+
+CREATE TABLE test_tag (
+    test_id int NOT NULL REFERENCES test_case(id) ON DELETE CASCADE,
+    test_run_id int NOT NULL REFERENCES test_run(id) ON DELETE CASCADE,
+    tag varchar(200)  NOT NULL,
+    PRIMARY KEY (test_run_id, test_id, tag)
+);
+
+CREATE TABLE keyword_tree (
+    fingerprint varchar(100) PRIMARY KEY,
+    keyword text,
+    library text,
+    status text,
+    arguments json
+);
+
+CREATE TABLE tree_hierarchy (
+    fingerprint varchar(100) REFERENCES keyword_tree(fingerprint),
+    subtree varchar(100) REFERENCES keyword_tree(fingerprint),
+    call_index varchar(200),
+    PRIMARY KEY (fingerprint, subtree, call_index)
+);
+
+CREATE TABLE keyword_statistics (
+    test_run_id int NOT NULL REFERENCES test_run(id) ON DELETE CASCADE,
+    fingerprint varchar(100) REFERENCES keyword_tree(fingerprint),
+    calls int,
+    max_execution_time int,
+    min_execution_time int,
+    cumulative_execution_time int,
+    max_call_depth int,
+    PRIMARY KEY (test_run_id, fingerprint)
+);

--- a/test_archiver/schemas/schema_mysql.sql
+++ b/test_archiver/schemas/schema_mysql.sql
@@ -1,3 +1,4 @@
+SET SESSION sql_mode = 'ANSI_QUOTES';
 CREATE TABLE schema_updates (
     id serial PRIMARY KEY,
     schema_version int UNIQUE NOT NULL,
@@ -20,7 +21,7 @@ CREATE TABLE test_run (
     archived_using varchar(200),
     archiver_version varchar(200),
     generator varchar(200),
-    `generated` timestamp,
+    "generated" timestamp,
     rpa boolean,
     dryrun boolean,
     ignored boolean DEFAULT false,

--- a/test_archiver/tests/unit/test_archiver_module.py
+++ b/test_archiver/tests/unit/test_archiver_module.py
@@ -16,7 +16,7 @@ class TestTestItem(unittest.TestCase):
     def test_parent_suite(self):
         self.assertEqual(self.item.parent_suite(), None)
 
-        test_run = archiver.TestRun(self.archiver, 'unittests', 'never', 'unittests', None, None)
+        test_run = archiver.TestRun(self.archiver, 'unittests', None, 'unittests', None, None)
         self.archiver.stack.append(test_run)
         self.assertEqual(self.item.parent_suite(), None)
 
@@ -35,7 +35,7 @@ class TestTestItem(unittest.TestCase):
     def test_parent_test(self):
         self.assertEqual(self.item.parent_test(), None)
 
-        test_run = archiver.TestRun(self.archiver, 'unittests', 'never', 'unittests', None, None)
+        test_run = archiver.TestRun(self.archiver, 'unittests', None, 'unittests', None, None)
         self.archiver.stack.append(test_run)
         self.assertEqual(self.item.parent_test(), None)
 
@@ -58,7 +58,7 @@ class TestTestItem(unittest.TestCase):
     def test_parent_item(self):
         self.assertEqual(self.item._parent_item(), None)
 
-        test_run = archiver.TestRun(self.archiver, 'unittests', 'never', 'unittests', None, None)
+        test_run = archiver.TestRun(self.archiver, 'unittests', None, 'unittests', None, None)
         self.archiver.stack.append(test_run)
         self.assertEqual(self.item._parent_item(), test_run)
 
@@ -82,7 +82,7 @@ class TestTestItem(unittest.TestCase):
         self.assertEqual(self.item.test_run_id(), None)
 
         self.mock_db.insert_and_return_id.return_value = 1234
-        self.archiver.begin_test_run('unittests', 'never', 'unittests', None, None)
+        self.archiver.begin_test_run('unittests', None, 'unittests', None, None)
         self.assertEqual(self.item.test_run_id(), 1234)
 
 
@@ -256,7 +256,7 @@ class TestArchiverClass(unittest.TestCase):
         self.assertEqual(suite3.execution_path(), 'path-to-s1-s2')
 
     def test_test_execution_paths_are_set(self):
-        self.archiver.begin_test_run('unittests', 'never', 'unittests', None, None)
+        self.archiver.begin_test_run('unittests', None, 'unittests', None, None)
         suite1 = self.archiver.begin_suite('mock suite 1', execution_path='path-to-s1')
         self.assertEqual(suite1.execution_path(), 'path-to-s1')
 
@@ -275,7 +275,7 @@ class TestArchiverClass(unittest.TestCase):
         self.assertEqual(suite3.execution_path(), 'path-to-s11-t2')
 
     def test_keyword_and_log_message_execution_paths_are_generated(self):
-        self.archiver.begin_test_run('unittests', 'never', 'unittests', None, None)
+        self.archiver.begin_test_run('unittests', None, 'unittests', None, None)
         suite1 = self.archiver.begin_suite('mock suite 1')
         self.assertEqual(suite1.execution_path(), 's1')
 

--- a/test_archiver/tests/unit/test_archiver_module.py
+++ b/test_archiver/tests/unit/test_archiver_module.py
@@ -1,9 +1,12 @@
 # pylint: disable=W0212
 
 import unittest
+import datetime
 from mock import Mock
 
 from test_archiver import configs, archiver
+
+some_timestamp = datetime.datetime.now().isoformat(timespec='milliseconds')
 
 class TestTestItem(unittest.TestCase):
 
@@ -193,13 +196,13 @@ class TestLogMessage(unittest.TestCase):
         sut_archiver = archiver.Archiver(self.mock_db, config)
         sut_archiver.begin_suite('Some suite of tests')
 
-        message = archiver.LogMessage(sut_archiver, 'WARN', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'WARN', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
-        message = archiver.LogMessage(sut_archiver, 'INFO', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'INFO', some_timestamp)
         message.insert('Some log message')
         self.assertEqual(self.mock_db.insert.call_count, 2)
-        message = archiver.LogMessage(sut_archiver, 'TRACE', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'TRACE', some_timestamp)
         message.insert('Some log message')
         self.assertEqual(self.mock_db.insert.call_count, 3)
 
@@ -208,13 +211,13 @@ class TestLogMessage(unittest.TestCase):
         sut_archiver = archiver.Archiver(self.mock_db, config)
         sut_archiver.begin_suite('Some suite of tests')
 
-        message = archiver.LogMessage(sut_archiver, 'WARN', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'WARN', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
-        message = archiver.LogMessage(sut_archiver, 'INFO', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'INFO', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
-        message = archiver.LogMessage(sut_archiver, 'TRACE', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'TRACE', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
 
@@ -223,16 +226,16 @@ class TestLogMessage(unittest.TestCase):
         sut_archiver = archiver.Archiver(self.mock_db, config)
         sut_archiver.begin_suite('Some suite of tests')
 
-        message = archiver.LogMessage(sut_archiver, 'WARN', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'WARN', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
-        message = archiver.LogMessage(sut_archiver, 'INFO', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'INFO', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
-        message = archiver.LogMessage(sut_archiver, 'TRACE', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'TRACE', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
-        message = archiver.LogMessage(sut_archiver, 'FOO', 'some_timestamp')
+        message = archiver.LogMessage(sut_archiver, 'FOO', some_timestamp)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
 

--- a/test_archiver/tests/unit/test_archiver_module.py
+++ b/test_archiver/tests/unit/test_archiver_module.py
@@ -6,7 +6,7 @@ from mock import Mock
 
 from test_archiver import configs, archiver
 
-some_timestamp = datetime.datetime.now().isoformat(timespec='milliseconds')
+SOME_TIMESTAMP = datetime.datetime.now().isoformat(timespec='milliseconds')
 
 class TestTestItem(unittest.TestCase):
 
@@ -196,13 +196,13 @@ class TestLogMessage(unittest.TestCase):
         sut_archiver = archiver.Archiver(self.mock_db, config)
         sut_archiver.begin_suite('Some suite of tests')
 
-        message = archiver.LogMessage(sut_archiver, 'WARN', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'WARN', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
-        message = archiver.LogMessage(sut_archiver, 'INFO', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'INFO', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.assertEqual(self.mock_db.insert.call_count, 2)
-        message = archiver.LogMessage(sut_archiver, 'TRACE', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'TRACE', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.assertEqual(self.mock_db.insert.call_count, 3)
 
@@ -211,13 +211,13 @@ class TestLogMessage(unittest.TestCase):
         sut_archiver = archiver.Archiver(self.mock_db, config)
         sut_archiver.begin_suite('Some suite of tests')
 
-        message = archiver.LogMessage(sut_archiver, 'WARN', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'WARN', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
-        message = archiver.LogMessage(sut_archiver, 'INFO', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'INFO', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
-        message = archiver.LogMessage(sut_archiver, 'TRACE', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'TRACE', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_called_once()
 
@@ -226,16 +226,16 @@ class TestLogMessage(unittest.TestCase):
         sut_archiver = archiver.Archiver(self.mock_db, config)
         sut_archiver.begin_suite('Some suite of tests')
 
-        message = archiver.LogMessage(sut_archiver, 'WARN', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'WARN', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
-        message = archiver.LogMessage(sut_archiver, 'INFO', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'INFO', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
-        message = archiver.LogMessage(sut_archiver, 'TRACE', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'TRACE', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
-        message = archiver.LogMessage(sut_archiver, 'FOO', some_timestamp)
+        message = archiver.LogMessage(sut_archiver, 'FOO', SOME_TIMESTAMP)
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
 


### PR DESCRIPTION
Provide mysql support using [PyMySQL ](https://pypi.org/project/PyMySQL/) connector, which is MIT licensed.
Includes fixes for time adjust seconds functionality which became evident due to difference in timestamps between mysql and postgres.
MySqlDatabase class has been added into the database.py file. Tempted to move each class into a package, but less changes this way, which may make initial review easier.
Biggest changes in schema were moving from text to varchar for keys etc. Opted for larger and hence more future proof sizes, but these choices should be scrutinised for correctness.
Postgres array is saved as JSON in mysql version.
--require_ssl option not implemented.