### PR TITLE
Bug/46 - Log message execution paths wrong

### DIFF
--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -135,6 +135,7 @@ class FingerprintedItem(TestItem):
         return self.full_name
 
     def finish(self):
+        self.execution_path() # Make sure this is called before exiting any item
         self.handle_child_statuses()
         if not self.status:
             if self.execution_status:

--- a/test_archiver/tests/unit/test_archiver_module.py
+++ b/test_archiver/tests/unit/test_archiver_module.py
@@ -293,10 +293,10 @@ class TestArchiverClass(unittest.TestCase):
         keyword1 = self.archiver.begin_keyword('mock kw', 'unitests', 'setup')
         self.assertEqual(keyword1.execution_path(), 's1-t1-k1')
         keyword2 = self.archiver.begin_keyword('mock kw', 'unitests', 'kw')
-        self.assertEqual(keyword2.execution_path(), 's1-t1-k1-k1')
         self.archiver.end_keyword()
         keyword3 = self.archiver.begin_keyword('mock kw', 'unitests', 'kw')
         self.assertEqual(keyword3.execution_path(), 's1-t1-k1-k2')
+        self.assertEqual(keyword2.execution_path(), 's1-t1-k1-k1')
 
     def test_execution_context(self):
         self.assertEqual(self.archiver.execution_context, 'default')


### PR DESCRIPTION
Fixed by making sure execution_tree() is called for every fingerprinted item