### PR TITLE
Add parameter "port" to _connect

### DIFF
--- a/test_archiver/database.py
+++ b/test_archiver/database.py
@@ -180,6 +180,7 @@ class PostgresqlDatabase(BaseDatabase):
 
         self._connection = psycopg2.connect(
             host=self.host,
+            port=self.port,
             database=self.database,
             user=self.user,
             password=self.password,


### PR DESCRIPTION
The parameter "port" is now passed to the function and can connect to a non-standard port.