### PR TITLE
Add option to archive complete messages

### DIFF
--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -91,6 +91,7 @@ class Config(object, metaclass=Singleton):
                                                               cast_as=bool)
         self.ignore_logs = self.resolve_option('ignore_logs', default=False, cast_as=bool)
         self.ignore_logs_below = self.resolve_option('ignore_logs_below', default=None)
+        self.max_log_message_length = self.resolve_option('max_log_message_length', cast_as=str, default='2000')
 
         # Adjust timestamps
         self.time_adjust_secs = self.resolve_option('time_adjust_secs', default=0, cast_as=int)
@@ -187,6 +188,11 @@ def base_argument_parser(description):
                              'By default archives all available log messages.'))
     group.add_argument('--ignore-logs', action='store_true', default=None,
                        help='Do not archive any log messages')
+    group.add_argument('--max_log_message_length',
+                       help="""Specify how many characters of the log message that is archived.
+                               full: archives the complete log.
+                               positive integers: archives number of characters from the beginning.
+                               negative integers: archives number of characters from the end.""")
 
     group = parser.add_argument_group('Adjust timestamps')
     group.add_argument('--time-adjust-secs', dest='time_adjust_secs',

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -37,16 +37,28 @@ LOG_LEVEL_MAP["FAIL"] = 50
 LOG_LEVEL_CUT_OFF_OPTIONS = ('TRACE', 'DEBUG', 'INFO', 'WARN')
 
 
-class Config:
+class Singleton(type):
+    _instance = {}
 
-    def __init__(self, cli_args=None, file_config=None):
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instance:
+            cls._instance[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instance[cls]
+
+
+class Config(object, metaclass=Singleton):
+
+    def __init__(self):
+        self._changes = 'changes'
+        self._default = 'default'
+
+    def resolve(self, cli_args):
         self._cli_args = cli_args
+        file_config = cli_args.config_file
         if isinstance(file_config, str):
             self._file_config = read_config_file(file_config)
         else:
             self._file_config = file_config or {}
-        self._changes = 'changes'
-        self._default = 'default'
         self._resolve_options()
 
     def _resolve_options(self):

--- a/test_archiver/output_parser.py
+++ b/test_archiver/output_parser.py
@@ -849,7 +849,11 @@ Json file which contains information from the changed files for each repo. The f
 
 
 def main():
-    config, args = configs.configuration(argument_parser)
+
+    args = argument_parser().parse_args()
+    config = configs.Config()
+    config.resolve(args)
+
     connection = archiver.database_connection(config)
 
     build_number_cache = {}


### PR DESCRIPTION
This pull request allows configuring how log messages should be archived.  The "max_log_message_length" parameter can be configured from the command line and in the configuration file. The default value is 2000 characters to be backward compatible. The value of "max_log_message_length" can be the following:
"full": archives full log message
<positive integer>: archives number of characters from the beginning of the log message.
<negative integer>: archives number of characters from the end of the log message.

The Config class is changed to use the singleton design pattern to allow easy access and distribution of the configuration across Python modules, classes, and functions within the project.