### PR TITLE
time adjust generated and fingerprint

### DIFF
--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -722,7 +722,7 @@ def adjusted_timestamp_to_datetime(timestamp, time_adjust_secs=0):
 
 def adjusted_timestamp(timestamp, time_adjust_secs=0):
     adjusted_stamp = timestamp
-    if time_adjust_secs != 0:
+    if timestamp and time_adjust_secs != 0:
         adjusted_datetime = adjusted_timestamp_to_datetime(timestamp, time_adjust_secs)
         adjusted_stamp = adjusted_datetime.isoformat(timespec='milliseconds')
     return adjusted_stamp

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -206,7 +206,8 @@ class FingerprintedItem(TestItem):
                 'setup_status': self.setup_status,
                 'execution_status': self.execution_status,
                 'teardown_status': self.teardown_status,
-                'start_time': self.start_time,
+                'start_time': adjusted_timestamp(self.start_time, self.archiver.time_adjust.secs())
+                              if self.start_time else None,
                 'elapsed': self.elapsed_time,
                 'setup_elapsed': self.elapsed_time_setup,
                 'execution_elapsed': self.elapsed_time_execution,
@@ -254,7 +255,8 @@ class TestRun(FingerprintedItem):
         super(TestRun, self).__init__(archiver, '')
         data = {'archived_using': archived_using,
                 'archiver_version': version.ARCHIVER_VERSION,
-                'generated': generated,
+                'generated': adjusted_timestamp(generated, self.archiver.time_adjust.secs())
+                             if generated else None,
                 'generator': generator,
                 'rpa': rpa,
                 'dryrun': dryrun,


### PR DESCRIPTION
Time stamps need to be adjust also in TestRun __init__ if there is a generated timestamp and in status_and_fingerprint_values of FingerprintedItem.
These timestamps were missed from the adjusted timestamps feature. If they are not adjusted then the date/time will not line up when cross referencing between tables with timestamps.
Additionally add a failsafe in adjusted_timestamp_to_datetime against trying to update a None timestamp.