### PR TITLE
Feature/parser accepting missing time values from testcases

### DIFF
--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -7,6 +7,9 @@ from datetime import datetime, timedelta
 from collections import defaultdict
 
 from . import database, version, archiver_listeners
+from .configs import Config
+
+config = Config()
 
 SUPPORTED_TIMESTAMP_FORMATS = (
         "%Y%m%d %H:%M:%S.%f",
@@ -22,8 +25,6 @@ SUPPORTED_TIMESTAMP_FORMATS = (
         "%Y-%m-%dT%H:%M:%S",
         "%Y-%m-%dT%H:%M:%S.%f%z",
     )
-
-MAX_LOG_MESSAGE_LENGTH = 2000
 
 
 class TimeAdjust:
@@ -463,9 +464,16 @@ class LogMessage(TestItem):
     def insert(self, content):
         if (not self.archiver.config.ignore_logs and
                 not self.archiver.config.log_level_ignored(self.log_level)):
+            message_length = config.max_log_message_length
+            if message_length == 'full':
+                message = content
+            elif type(message_length) == int and message_length < 0:
+                message = content[message_length:]
+            else:
+                message = type(message_length) == int and content[:message_length]
             data = {'test_run_id': self.test_run_id(),
                     'timestamp': adjusted_timestamp(self.timestamp, self.archiver.time_adjust.secs()),
-                    'log_level': self.log_level, 'message': content[:MAX_LOG_MESSAGE_LENGTH],
+                    'log_level': self.log_level, 'message': message,
                     'test_id': self.parent_test().id if self.parent_test() else None,
                     'suite_id': self.parent_suite().id,
                     'execution_path': self.execution_path()}

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -91,6 +91,7 @@ class Config(object, metaclass=Singleton):
                                                               cast_as=bool)
         self.ignore_logs = self.resolve_option('ignore_logs', default=False, cast_as=bool)
         self.ignore_logs_below = self.resolve_option('ignore_logs_below', default=None)
+        self.max_log_message_length = self.resolve_option('max_log_message_length', cast_as=str, default='2000')
 
         # Adjust timestamps
         self.time_adjust_secs = self.resolve_option('time_adjust_secs', default=0, cast_as=int)
@@ -187,6 +188,11 @@ def base_argument_parser(description):
                              'By default archives all available log messages.'))
     group.add_argument('--ignore-logs', action='store_true', default=None,
                        help='Do not archive any log messages')
+    group.add_argument('--max_log_message_length',
+                       help="""Specify how many characters of the log message that is archived.
+                               full: archives the complete log.
+                               positive integers: archives number of characters from the beginning.
+                               negative integers: archives number of characters from the end.""")
 
     group = parser.add_argument_group('Adjust timestamps')
     group.add_argument('--time-adjust-secs', dest='time_adjust_secs',

--- a/test_archiver/configs.py
+++ b/test_archiver/configs.py
@@ -37,16 +37,28 @@ LOG_LEVEL_MAP["FAIL"] = 50
 LOG_LEVEL_CUT_OFF_OPTIONS = ('TRACE', 'DEBUG', 'INFO', 'WARN')
 
 
-class Config:
+class Singleton(type):
+    _instance = {}
 
-    def __init__(self, cli_args=None, file_config=None):
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instance:
+            cls._instance[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instance[cls]
+
+
+class Config(object, metaclass=Singleton):
+
+    def __init__(self):
+        self._changes = 'changes'
+        self._default = 'default'
+
+    def resolve(self, cli_args):
         self._cli_args = cli_args
+        file_config = cli_args.config_file
         if isinstance(file_config, str):
             self._file_config = read_config_file(file_config)
         else:
             self._file_config = file_config or {}
-        self._changes = 'changes'
-        self._default = 'default'
         self._resolve_options()
 
     def _resolve_options(self):

--- a/test_archiver/output_parser.py
+++ b/test_archiver/output_parser.py
@@ -183,7 +183,7 @@ class XUnitOutputParser(XmlOutputParser):
         elif name == 'testcase':
             class_name = attrs.getValue('classname')
             self.archiver.begin_test(attrs.getValue('name'), class_name=class_name)
-            elapsed = int(float(attrs.getValue('time')) * 1000)
+            elapsed = int(float(attrs.getValue('time')) * 1000) if 'time' in attrs.getNames() else None
             self.archiver.begin_status('PASS', elapsed=elapsed)
         elif name == 'failure':
             self.archiver.update_status('FAIL')

--- a/test_archiver/output_parser.py
+++ b/test_archiver/output_parser.py
@@ -263,7 +263,7 @@ class JUnitOutputParser(XmlOutputParser):
         elif name == 'testcase':
             class_name = attrs.getValue('classname')
             self.archiver.begin_test(attrs.getValue('name'), class_name=class_name)
-            elapsed = int(float(attrs.getValue('time')) * 1000)
+            elapsed = int(float(attrs.getValue('time')) * 1000) if 'time' in attrs.getNames() else None
             self.archiver.begin_status('PASS', elapsed=elapsed)
         elif name == 'failure':
             self.archiver.update_status('FAIL')

--- a/test_archiver/output_parser.py
+++ b/test_archiver/output_parser.py
@@ -852,7 +852,11 @@ Json file which contains information from the changed files for each repo. The f
 
 
 def main():
-    config, args = configs.configuration(argument_parser)
+
+    args = argument_parser().parse_args()
+    config = configs.Config()
+    config.resolve(args)
+
     connection = archiver.database_connection(config)
 
     build_number_cache = {}


### PR DESCRIPTION
Missing time value caused parsers to fail in cases where failed test cases did not have a time value. 

This change is also tested to be compatible with epimetheus.