### PR TITLE
Fixes archiving of log messages after max length option changes

### DIFF
--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -465,15 +465,17 @@ class LogMessage(TestItem):
         if (not self.archiver.config.ignore_logs and
                 not self.archiver.config.log_level_ignored(self.log_level)):
             message_length = config.max_log_message_length
-            if message_length == 'full':
-                message = content
-            elif isinstance(message_length, int) and message_length < 0:
+
+            if message_length < 0:
                 message = content[message_length:]
+            elif message_length > 0:
+                message = content[:message_length]
             else:
-                message = isinstance(message_length, int) and content[:message_length]
+                message = content
             data = {'test_run_id': self.test_run_id(),
                     'timestamp': adjusted_timestamp(self.timestamp, self.archiver.time_adjust.secs()),
-                    'log_level': self.log_level, 'message': message,
+                    'log_level': self.log_level,
+                    'message': message,
                     'test_id': self.parent_test().id if self.parent_test() else None,
                     'suite_id': self.parent_suite().id,
                     'execution_path': self.execution_path()}

--- a/test_archiver/tests/unit/test_archiver_module.py
+++ b/test_archiver/tests/unit/test_archiver_module.py
@@ -244,6 +244,36 @@ class TestLogMessage(unittest.TestCase):
         message.insert('Some log message')
         self.mock_db.insert.assert_not_called()
 
+    def test_max_log_message_length_is_used(self):
+        config = configs.Config()
+        config.resolve(file_config={'max_log_message_length': 10})
+        sut_archiver = archiver.Archiver(self.mock_db, config)
+        sut_archiver.begin_suite('Some suite of tests')
+        message = archiver.LogMessage(sut_archiver, 'WARN', 'some_timestamp')
+        message.insert('Some log message')
+        self.assertEqual(self.mock_db.insert.mock_calls[0].args[1]['message'], "Some log m")
+
+        config.resolve(file_config={'max_log_message_length': -10})
+        sut_archiver = archiver.Archiver(self.mock_db, config)
+        sut_archiver.begin_suite('Some suite of tests')
+        message = archiver.LogMessage(sut_archiver, 'WARN', 'some_timestamp')
+        message.insert('Some log message')
+        self.assertEqual(self.mock_db.insert.mock_calls[1].args[1]['message'], "og message")
+
+        config.resolve(file_config={'max_log_message_length': 'full'})
+        sut_archiver = archiver.Archiver(self.mock_db, config)
+        sut_archiver.begin_suite('Some suite of tests')
+        message = archiver.LogMessage(sut_archiver, 'WARN', 'some_timestamp')
+        message.insert('Some log message')
+        self.assertEqual(self.mock_db.insert.mock_calls[2].args[1]['message'], 'Some log message')
+
+        config.resolve(file_config={'max_log_message_length': 0})
+        sut_archiver = archiver.Archiver(self.mock_db, config)
+        sut_archiver.begin_suite('Some suite of tests')
+        message = archiver.LogMessage(sut_archiver, 'WARN', 'some_timestamp')
+        message.insert('Some log message')
+        self.assertEqual(self.mock_db.insert.mock_calls[3].args[1]['message'], 'Some log message')
+
 
 class TestArchiverClass(unittest.TestCase):
 

--- a/test_archiver/version.py
+++ b/test_archiver/version.py
@@ -1,6 +1,6 @@
 import os
 
-ARCHIVER_VERSION = "2.6.0"
+ARCHIVER_VERSION = "2.6.1"
 
 
 def dynamic_package_version():


### PR DESCRIPTION
Fixes a regression from adding max log message length option along with unit tests for the feature