### PR TITLE
Allow extension of data tables against test runs via 'table record' metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ There are meta data that are useful to add with the results. Some testing framew
 
 `--metadata NAME:VALUE`
 
+### Table Extension metadata
+
+To allow extension of data tables against test runs, the metadata tag __table#<table_name>__ can be used with a __<table_name>__ record specified by a json value.
+For example a metadata entry
+`table#host_info:{"host_name":"test_machine01", "host_location":"Paris", "user":"James"}`
+would result in a record written to the database table __host_info__, with the json specified fields __host_name, host_location, user__ against TestArchiver's __suite_id__ and __test_run_id__.
+
+This will allow for extended information, specific to a test environment, to be defined as required by a test team.
+
+This table is not created by TestArchiver, so the user needs to ensure it is created by a different process.
+
+The full json value is also written to the metadata table as per any other metadata.
+
 ## Test series and teams
 
 In the data model, each test result file is represented as single test run. These test runs are linked and organized into builds in in different result series. Depending on the situation the series can be e.g. CI build jobs or different branches. By default if no series is specified the results are linked to a default series with autoincrementing build numbers. Different test runs (from different testing frameworks or parallel executions) that belong together can be organized into the same build. Different test series are additionally organized by team. Series name and build number/id are separated by `#`.

--- a/test_archiver/archiver.py
+++ b/test_archiver/archiver.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+import json
 from hashlib import sha1
 from datetime import datetime, timedelta
 from collections import defaultdict
@@ -321,6 +322,7 @@ class Suite(FingerprintedItem):
                 self.metadata["time_adjust_secs_total"] = self.archiver.time_adjust.secs()
 
         for name in self.metadata:
+            table_prefix = 'table#'
             content = self.metadata[name]
             data = {'name': name, 'value': content,
                     'suite_id': self.id, 'test_run_id': self.test_run_id()}
@@ -333,6 +335,14 @@ class Suite(FingerprintedItem):
                 self.archiver.test_series[series_name] = build_number
             elif name == 'team':
                 self.archiver.team = content
+            elif name.startswith(table_prefix):
+                table = name[len(table_prefix):]
+                if table:
+                    fields = json.loads(content)
+                    fields['suite_id'] = self.id
+                    fields['test_run_id'] = self.test_run_id()
+                    self.archiver.db.insert(table, fields)
+
 
     def register_metadata(self, name=None, value=None):
         if name:


### PR DESCRIPTION
To allow extension of data tables against test runs, proposing the use of a special metadata tag, similar to `series#` and `team#`, namely `table#<table_name>` whose value is a json record defining the field to be written to a table with name <table_name>.

For example a metadata entry
`table#host_info:{"host_name":"test_machine01", "host_location":"Paris", "user":"James"}`
would result in a record written to the database table `host_info`, with the json specified parameters `host_name, host_location, user` against TestArchiver's `suite_id` and `test_run_id`.

This will allow for extended information, specific to a test environment, to be defined as required by a test team.
TestArchiver would remain agnostic of this table and its contents, leaving the user to ensure the table is created via a different process and its field match the json data.
The full json value is also written to the metadata table as per any other metadata.