### PR TITLE
Ignore break in Robot Framework 5 output

### DIFF
--- a/test_archiver/output_parser.py
+++ b/test_archiver/output_parser.py
@@ -102,7 +102,7 @@ class RobotFrameworkOutputParser(XmlOutputParser):
             self.archiver.begin_metadata(attrs.getValue('name'))
         elif name == 'doc':
             pass
-        elif name in ('arguments', 'tags', 'metadata', 'if', 'return'):
+        elif name in ('arguments', 'tags', 'metadata', 'if', 'return', 'break'):
             pass
         else:
             print("WARNING: begin unknown item '{}'".format(name))
@@ -150,7 +150,7 @@ class RobotFrameworkOutputParser(XmlOutputParser):
             self.archiver.end_metadata(self.content())
         elif name == 'doc':
             pass
-        elif name in ('arguments', 'tags', 'metadata', 'if', 'return'):
+        elif name in ('arguments', 'tags', 'metadata', 'if', 'return', 'break'):
             pass
         else:
             print("WARNING: ending unknown item '{}'".format(name))


### PR DESCRIPTION
Robot Framework v5 allows the use of BREAK tests and resource files. It generates break elements in the output file. When we use testarchiver to parse the file it produces a lot of warning messages.